### PR TITLE
This fixes CVE-2024-42367: 

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ phonenumbers==8.13.39
 twilio==9.1.1
 python-socketio==5.11.3
 pytest-asyncio==0.23.7
-aiohttp==3.9.5
+aiohttp==3.10.5
 slack_bolt==1.19.1
 slack_sdk==3.30.0
 pytest-aiohttp==1.0.5


### PR DESCRIPTION
In aiohttp prior to 3.10.5, compressed files as symlinks are not protected from path traversal.