### PR TITLE
This fixes CVE-2024-39705

### DIFF
--- a/eppo-librarian/requirements.txt
+++ b/eppo-librarian/requirements.txt
@@ -1,4 +1,4 @@
 pandas==2.2.2
 chromadb==0.5.5
-nltk==3.8.2
+nltk==3.9.1
 lxml==5.2.2


### PR DESCRIPTION
3.8.2 was pulled apparently.

NLTK through 3.8.1 allows remote code execution if untrusted packages have pickled Python code, and the integrated data package download functionality is used. This affects, for example, averaged_perceptron_tagger and punkt.